### PR TITLE
[unity-webgl]babel 编译超过500k代码时 报错，将compact设置为false

### DIFF
--- a/package/Javascripts~/glob-js/index.js
+++ b/package/Javascripts~/glob-js/index.js
@@ -19,7 +19,8 @@ function buildForBrowser(allJSFile, outputpath) {
             cwd: __dirname,
             "presets": [
                 ["@babel/preset-env", { targets: { chrome: "84", esmodules: false } }]
-            ]
+            ],
+            compact: false,
         }).code}
         })`;
     })


### PR DESCRIPTION
![8@QK)B(SGS~J0DQ2I4E@FJY](https://user-images.githubusercontent.com/3347875/178430908-5964a2d5-a063-4fa6-b4d3-3edd5b471b85.png)
