### PR TITLE
在js测给Func<object>返回一个结构体，能复现出GetTypeIdFromResult产生的bug

### DIFF
--- a/package/Javascripts~/PuertsDLLMock/mixins/getFromJSReturn.ts
+++ b/package/Javascripts~/PuertsDLLMock/mixins/getFromJSReturn.ts
@@ -1,4 +1,4 @@
-import { GetType, jsFunctionOrObjectFactory, PuertsJSEngine, setOutValue32 } from "../library";
+import { GetType, JSFunction, jsFunctionOrObjectFactory, PuertsJSEngine, setOutValue32 } from "../library";
 /**
  * mixin
  * C#调用JS时，获取JS函数返回值
@@ -34,7 +34,18 @@ export default function WebGLBackendGetFromJSReturnAPI(engine: PuertsJSEngine) {
             return engine.csharpObjectMap.getCSIdentifierFromObject(engine.lastReturnCSResult);
         },
         GetTypeIdFromResult: function (resultInfo: IntPtr) {
-            return GetType(engine, engine.lastReturnCSResult);
+            var value = engine.lastReturnCSResult;
+            var typeid = 0;
+            if (value instanceof JSFunction) {
+                typeid = (value._func as any)["$cid"];
+            } else {
+                typeid = (value as any)["$cid"];
+            }
+
+            if (!typeid) {
+                throw new Error('cannot find typeid for' + value)
+            }
+            return typeid
         },
         GetFunctionFromResult: function (resultInfo: IntPtr): JSFunctionPtr {
             var jsfunc = jsFunctionOrObjectFactory.getOrCreateJSFunction(engine.lastReturnCSResult);

--- a/projects/8_UnitTest/Assets/Test/PuertsTest.cs
+++ b/projects/8_UnitTest/Assets/Test/PuertsTest.cs
@@ -170,6 +170,13 @@ namespace PuertsTest
             AssertAndPrint("CSGetJSObjectReturnFromJS", JSValueHandler(initialValue) == initialValue);
             return initialValue;
         }
+
+        public Func<object> ReturnAnyTestFunc;
+
+        public void InvokeReturnAnyTestFunc(TestStruct srcValue){
+            var ret = (TestStruct)ReturnAnyTestFunc.Invoke();
+            AssertAndPrint("InvokeReturnNativeObjectStructTestFunc", srcValue.value == ret.value);
+        }
     }
 
     public class PuertsTest : MonoBehaviour

--- a/projects/8_UnitTest/Assets/Test/Resources/datatype-test.mjs
+++ b/projects/8_UnitTest/Assets/Test/Resources/datatype-test.mjs
@@ -93,6 +93,11 @@ var init = function (testHelper) {
     // assertAndPrint("JSGetJSObjectOutArgFromCS", puerts.$unref(outRef) == oJSObject);
     assertAndPrint("JSGetJSObjectReturnFromCS", rJSObject == oJSObject);
 
+    testHelper.ReturnAnyTestFunc = ()=>{
+        return new cs.PuertsTest.TestStruct(2);
+    }
+    testHelper.InvokeReturnAnyTestFunc(new cs.PuertsTest.TestStruct(2));
+
     debugger;
 };
 


### PR DESCRIPTION
由于返回值类型是object，所以走了DataTranslate中的AnyTranslator，进而调用了getValueApi.GetTypeId -> PuertsDLL.GetTypeIdFromResult -> getFromJSReturn.ts中的GetTypeIdFromResult

getFromJSReturn.ts中的GetTypeIdFromResult 目前的实现并没有返回对象的类型id，而是返回32。所以引起报错。

![image](https://user-images.githubusercontent.com/9474727/187351274-a7bac597-2d12-4336-bd04-726bb837943c.png)
