### PR TITLE
js number is double, use double instead of float for number args

### DIFF
--- a/packages/webgl/upm/Javascripts~/PuertsDLLMock/mixins/getFromJSArgument.ts
+++ b/packages/webgl/upm/Javascripts~/PuertsDLLMock/mixins/getFromJSArgument.ts
@@ -1,4 +1,4 @@
-import { FunctionCallbackInfoPtrManager, GetType, isBigInt, JSFunction, jsFunctionOrObjectFactory, PuertsJSEngine, setOutValue32, writeBigInt } from "../library";
+import { JSFunction, PuertsJSEngine } from "../library";
 
 // export function GetNumberFromValue(engine: PuertsJSEngine, isolate: IntPtr, value: MockIntPtr, isByRef: bool): number {
 //     return engine.functionCallbackInfoPtrManager.GetArgsByMockIntPtr(value);
@@ -46,30 +46,7 @@ import { FunctionCallbackInfoPtrManager, GetType, isBigInt, JSFunction, jsFuncti
 //     setOutValue32(engine, lengthOffset, ab.byteLength);
 //     return ptr;
 // }
-export function $GetArgumentFinalValue(engine: PuertsJSEngine, val: any, jsValueType: number, lengthOffset: number): number {
-    if (!jsValueType) jsValueType = GetType(engine, val);
-    switch (jsValueType) {
-        case 2: {
-            const ptr = writeBigInt(engine, val);
-            // ValueIsBigInt可据此判断
-            setOutValue32(engine, lengthOffset, 8/*long == 8byte*/);
-            return ptr;
-        }
-        case 4: return +val;
-        case 8: return engine.JSStringToCSString(val, lengthOffset);
-        case 16: return +val;
-        case 32: return engine.csharpObjectMap.getCSIdentifierFromObject(val);
-        case 64: return jsFunctionOrObjectFactory.getOrCreateJSObject(val).id;
-        case 128: return jsFunctionOrObjectFactory.getOrCreateJSObject(val).id;
-        case 256: return jsFunctionOrObjectFactory.getOrCreateJSFunction(val).id;
-        case 512: return val.getTime();
-        case 1024:
-            var ptr = engine.unityApi._malloc(val.byteLength);
-            engine.unityApi.HEAPU8.set(val, ptr);
-            setOutValue32(engine, lengthOffset, val.byteLength);
-            return ptr;
-    }
-}
+
 /**
  * mixin
  * JS调用C#时，C#侧获取JS调用参数的值

--- a/packages/webgl/upm/Runtime/Plugins/WebGL/puerts.cpp
+++ b/packages/webgl/upm/Runtime/Plugins/WebGL/puerts.cpp
@@ -8,95 +8,114 @@ struct MockV8Value
     int FunctionCallbackInfo;
 };
 
-struct MockV8NumberOrDate
-{
-    int JSValueType;
-    float value;
-    int extra;
-    int FunctionCallbackInfo;
-};
+const int IntSizeOfV8Value = 4;
 
-extern "C" {
+void *GetPointerFromValue(void *isolate, MockV8Value *value, bool byref)
+{
+    if (byref)
+        value = (MockV8Value *)value->extra;
+    return (void *)(int)value->FinalValuePointer;
+}
+
+void *GetBufferFromValue(void *isolate, MockV8Value *value, int &length, bool byref)
+{
+    if (byref)
+        value = (MockV8Value *)value->extra;
+    length = value->extra;
+    return (void *)(int)value->FinalValuePointer;
+}
+
+double GetDoubleFromValue(void *isolate, MockV8Value *value, bool byref)
+{
+    if (byref)
+        value = (MockV8Value *)value->extra;
+    double *ptr = reinterpret_cast<double *>(value->FinalValuePointer);
+    return *ptr;
+}
+
+int64_t GetLongFromValue(void *isolate, MockV8Value *value, bool byref)
+{
+    if (byref)
+        value = (MockV8Value *)value->extra;
+    int64_t *ptr = reinterpret_cast<int64_t *>(value->FinalValuePointer);
+    return *ptr;
+}
+
+extern "C"
+{
     void *GetArgumentValue(void *infoptr, int index)
     {
         int step = sizeof(int);
-        return (void*)((long)infoptr + (index * 4 + 1) * step);
+        return (void *)((long)infoptr + (index * IntSizeOfV8Value + 1) * step);
     }
-    int GetArgumentType(void* isolate, void* infoptr, int index, bool byref)
+
+    int GetArgumentType(void *isolate, void *infoptr, int index, bool byref)
     {
         int step = sizeof(int);
-        MockV8Value *value = (MockV8Value*)((long)infoptr + (index * 4 + 1) * step);
+        MockV8Value *value = (MockV8Value *)((long)infoptr + (index * IntSizeOfV8Value + 1) * step);
         if (byref)
-            value = (MockV8Value*)value->extra;
+            value = (MockV8Value *)value->extra;
         return value->JSValueType;
     }
-    int GetJsValueType(void* isolate, MockV8Value* value, bool byref)
+
+    int GetJsValueType(void *isolate, MockV8Value *value, bool byref)
     {
         if (byref)
-            value = (MockV8Value*)value->extra;
+            value = (MockV8Value *)value->extra;
         return value->JSValueType;
     }
-    double GetNumberFromValue(void* isolate, MockV8NumberOrDate* value, bool byref)
+
+    double GetNumberFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8NumberOrDate*)value->extra;
-        return static_cast<double>(value->value);
+        return GetDoubleFromValue(isolate, value, byref);
     }
-    double GetDateFromValue(void* isolate, MockV8NumberOrDate* value, bool byref)
+
+    double GetDateFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8NumberOrDate*)value->extra;
-        return static_cast<double>(value->value);
+        return GetDoubleFromValue(isolate, value, byref);
     }
-    void* GetStringFromValue(void* isolate, MockV8Value* value, int &length, bool byref)
+
+    void *GetStringFromValue(void *isolate, MockV8Value *value, int &length, bool byref)
     {
-        if (byref)
-            value = (MockV8Value*)value->extra;
-        length = value->extra;
-        return (void*)(int)value->FinalValuePointer;
+        return GetBufferFromValue(isolate, value, length, byref);
     }
-    bool GetBooleanFromValue(void* isolate, MockV8Value* value, bool byref)
+
+    bool GetBooleanFromValue(void *isolate, MockV8Value *value, bool byref)
     {
         if (byref)
-            value = (MockV8Value*)value->extra;
+            value = (MockV8Value *)value->extra;
         return (bool)(int)value->FinalValuePointer;
     }
+
     bool ValueIsBigInt(void *isolate, MockV8Value *value, bool byref)
     {
         if (byref)
             value = (MockV8Value *)value->extra;
         return value->extra == 8; // long == 8byte
     }
+
     int64_t GetBigIntFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8Value *)value->extra;
-        int64_t *ptr = reinterpret_cast<int64_t *>(value->FinalValuePointer);
-        return *ptr;
+        return GetLongFromValue(isolate, value, byref);
     }
-    void* GetObjectFromValue(void* isolate, MockV8Value* value, bool byref)
+
+    void *GetObjectFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8Value*)value->extra;
-        return (void*)(int)value->FinalValuePointer;
+        return GetPointerFromValue(isolate, value, byref);
     }
-    void* GetFunctionFromValue(void* isolate, MockV8Value* value, bool byref)
+
+    void *GetFunctionFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8Value*)value->extra;
-        return (void*)(int)value->FinalValuePointer;
+        return GetPointerFromValue(isolate, value, byref);
     }
-    void* GetJSObjectFromValue(void* isolate, MockV8Value* value, bool byref)
+
+    void *GetJSObjectFromValue(void *isolate, MockV8Value *value, bool byref)
     {
-        if (byref)
-            value = (MockV8Value*)value->extra;
-        return (void*)(int)value->FinalValuePointer;
+        return GetPointerFromValue(isolate, value, byref);
     }
-    void* GetArrayBufferFromValue(void* isolate, MockV8Value* value, int &length, bool byref)
+
+    void *GetArrayBufferFromValue(void *isolate, MockV8Value *value, int &length, bool byref)
     {
-        if (byref)
-            value = (MockV8Value*)value->extra;
-        length = value->extra;
-        return (void*)(int)value->FinalValuePointer;
+        return GetBufferFromValue(isolate, value, length, byref);
     }
 }


### PR DESCRIPTION
js number传给c#的时候，用float接收存在精度不够的问题，替换为double接收，但相应的内存占用也会轻微增加。