### PR TITLE
通过脚本调用webgl-jsbuild时可自定义脚本内容

### DIFF
--- a/packages/webgl-jsbuild/upm/Editor/WebGLPostProcessor.cs
+++ b/packages/webgl-jsbuild/upm/Editor/WebGLPostProcessor.cs
@@ -5,6 +5,7 @@ using Puerts;
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 
 /**
  * ！！！！！！！！！！必读！！！！！！！
@@ -22,22 +23,26 @@ using System.Collections.Generic;
  * 如果你的游戏里使用了自定义的Loader，那么我建议您自己重新实现一个PostProcessor，以和你的Loader配套。
  */
 
-public class WebGLPuertsPostProcessor {
+public class WebGLPuertsPostProcessor
+{
 
-    public static List<string> fileGlobbers = new List<string> 
+    public static List<string> fileGlobbers = new List<string>
     {
         Application.dataPath + "/**/Resources/**/*.mjs",
         Application.dataPath + "/**/Resources/**/*.cjs",
         Path.GetFullPath("Packages/com.tencent.puerts.core/") + "/**/Resources/**/*.mjs"
     };
 
-    private static void run(string runEntry, string lastBuiltPath) 
+    private static void RunBuild(string runEntry, string lastBuiltPath, CustomScriptData[] customScripts)
     {
         string PuertsWebglJSRoot = Path.GetFullPath("Packages/com.tencent.puerts.webgl.jsbuild/Javascripts~/");
-        if (lastBuiltPath != null) {
+        if (lastBuiltPath != null)
+        {
             UnityEngine.Debug.Log("上一次构建路径：" + lastBuiltPath);
 
-        } else {
+        }
+        else
+        {
             lastBuiltPath = PuertsWebglJSRoot + "dist/";
             UnityEngine.Debug.Log("上一次构建路径为空，生成至：" + lastBuiltPath);
         }
@@ -52,7 +57,7 @@ public class WebGLPuertsPostProcessor {
         jsenv.Eval<Action<string>>(@"(function (requirePath) { 
             global.require = require('node:module').createRequire(requirePath)
         })")(PuertsWebglJSRoot);
-        
+
         Action<string, string> cpRuntimeJS = jsenv.Eval<Action<string, string>>(@"
             (function(puerRuntimeFilePath, targetPath) {
                 const { cp } = require('@puerts/shell-util');
@@ -61,24 +66,29 @@ public class WebGLPuertsPostProcessor {
             });
         ");
 
-        Action<string[], string> globjs = jsenv.Eval<Action<string[], string>>(@"
-            (function(csFileGlobbers, targetPath) {
-                const fileGlobbers = [];
-                for (let i = 0; i < csFileGlobbers.Length; i++) {
-                    fileGlobbers.push(csFileGlobbers.get_Item(i));
+        Action<string[], CustomScriptData[], string> globjs = jsenv.Eval<Action<string[], CustomScriptData[], string>>(@"
+            (function(csFileGlobbers, customScripts, targetPath) {
+                function toJsArray(csArray) {
+                    let results = [];
+                    for (let i = 0; i < csArray.Length; i++) {
+                        results.push(csArray.get_Item(i));
+                    }
+                    return results;
                 }
+
                 const globAllJS = require('.');
 
-                globAllJS." + runEntry + @"(fileGlobbers, targetPath);
+                globAllJS." + runEntry + @"(toJsArray(csFileGlobbers), customScripts ? toJsArray(customScripts) : null, targetPath);
                 
             });
         ");
-        
-        try {
+
+        try
+        {
             cpRuntimeJS(Path.GetFullPath("Packages/com.tencent.puerts.webgl/Javascripts~/PuertsDLLMock/dist/puerts-runtime.js"), lastBuiltPath);
-            globjs(fileGlobbers.ToArray(), lastBuiltPath);
-        } 
-        catch(Exception e) 
+            globjs(fileGlobbers.ToArray(), customScripts, lastBuiltPath);
+        }
+        catch (Exception e)
         {
             jsenv.Dispose();
             throw;
@@ -87,23 +97,48 @@ public class WebGLPuertsPostProcessor {
     }
 
     [MenuItem("puerts-webgl/build puerts-js for minigame", false, 11)]
-    public static void minigame() 
+    public static void BuildMinigame()
     {
-        run("buildForMinigame", GetLastBuildPath() != null ? GetLastBuildPath() + "/../minigame" : null);
+        RunBuild("buildForMinigame", GetLastBuildPath() != null ? GetLastBuildPath() + "/../minigame" : null, null);
+    }
+    public static void BuildMinigame(string outputRootPath, string extensioName = null)
+    {
+        RunBuild("buildForMinigame", GetLastBuildPath(), GetCustomScripts(outputRootPath, extensioName));
+    }
+    public static void BuildMinigame(Dictionary<string, string> customScripts)
+    {
+        CustomScriptData[] _customScripts = customScripts != null ? customScripts.Keys
+            .Select(resourceName => new CustomScriptData(resourceName, customScripts[resourceName]))
+            .ToArray() : null;
+        RunBuild("buildForMinigame", GetLastBuildPath(), _customScripts);
     }
 
+
     [MenuItem("puerts-webgl/build puerts-js for browser", false, 11)]
-    public static void browser() 
+    public static void BuildBrowser()
     {
-        run("buildForBrowser", GetLastBuildPath());
-    } 
+        RunBuild("buildForBrowser", GetLastBuildPath(), null);
+    }
+    public static void BuildBrowser(string outputRootPath, string extensioName = null)
+    {
+        RunBuild("buildForBrowser", GetLastBuildPath(), GetCustomScripts(outputRootPath, extensioName));
+    }
+    public static void BuildBrowser(Dictionary<string, string> scripts)
+    {
+        CustomScriptData[] _customScripts = scripts != null ? scripts.Keys
+            .Select(resourceName => new CustomScriptData(resourceName, scripts[resourceName]))
+            .ToArray() : null;
+        RunBuild("buildForBrowser", GetLastBuildPath(), _customScripts);
+    }
+
+
 
     [MenuItem("puerts-webgl/install", false, 0)]
-    static void npmInstall() 
+    static void NodeModulesInstall()
     {
         JsEnv jsenv = new Puerts.JsEnv();
         jsenv.UsingAction<string>();
-        try 
+        try
         {
             Action<string> npmInstaller = jsenv.Eval<Action<string>>(@"
                 (function(cwd) {
@@ -112,39 +147,103 @@ public class WebGLPuertsPostProcessor {
             ");
             npmInstaller(Path.GetFullPath("Packages/com.tencent.puerts.webgl.jsbuild/Javascripts~"));
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             UnityEngine.Debug.LogError("Npm install failed. you can cd into 'Packages/com.tencent.puerts.webgl.jsbuild/Javascripts~' to run 'npm install' by yourself");
         }
     }
 
 
-
     [MenuItem("PuerTS/WebGL/build puerts-js for minigame", true)]
     [MenuItem("PuerTS/WebGL/build puerts-js for browser", true)]
-    static bool NodeModulesInstalled() 
+    static bool NodeModulesInstalled()
     {
         return Directory.Exists(Path.GetFullPath("Packages/com.tencent.puerts.webgl.jsbuild/Javascripts~/node_modules"));
     }
     [MenuItem("PuerTS/WebGL/install", true)]
-    static bool NodeModulesNotInstalled() 
+    static bool NodeModulesInstallValidate()
     {
         return !NodeModulesInstalled();
     }
 
 
-    
-    protected static string GetLastBuildPath() {
+    protected static string GetLastBuildPath()
+    {
         return EditorPrefs.GetString("PUER_WEBGL_LAST_BUILDPATH");
     }
 
     [PostProcessBuildAttribute(1)]
-    public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject) 
+    public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
     {
-        if (target == BuildTarget.WebGL) 
+        if (target == BuildTarget.WebGL)
         {
             EditorPrefs.SetString("PUER_WEBGL_LAST_BUILDPATH", pathToBuiltProject);
             UnityEngine.Debug.Log("构建成功，请用puerts-webgl/build js构建js资源");
+        }
+    }
+
+
+
+    static CustomScriptData[] GetCustomScripts(string outputRootPath, string extensioName)
+    {
+        if (string.IsNullOrEmpty(outputRootPath) || !Directory.Exists(outputRootPath))
+            return null;
+        List<CustomScriptData> results = new List<CustomScriptData>();
+
+        Func<string, bool> filter = (string file) =>
+        {
+            return file != null && (file.EndsWith(".js") || file.EndsWith(".cjs") || file.EndsWith(".mjs"));
+        };
+
+        outputRootPath = outputRootPath.Replace("\\", "/");
+        if (!outputRootPath.EndsWith("/"))
+        {
+            outputRootPath += "/";
+        }
+
+        foreach (string file in ScanFiles(outputRootPath, filter))
+        {
+            string resourceName = file.Replace("\\", "/").Replace(outputRootPath, "");
+            if (!string.IsNullOrEmpty(extensioName) && Path.GetExtension(resourceName) != extensioName)
+            {
+                resourceName = resourceName.Substring(0, resourceName.Length - Path.GetExtension(resourceName).Length) + extensioName;
+            }
+            results.Add(new CustomScriptData(
+                resourceName,
+                System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(file))
+            ));
+        }
+        return results.ToArray();
+    }
+    static List<string> ScanFiles(string dirPath, Func<string, bool> filter)
+    {
+        List<string> files = new List<string>();
+
+        DirectoryInfo directoryInfo = new DirectoryInfo(dirPath);
+
+        foreach (FileInfo fileInfo in directoryInfo.GetFiles())
+        {
+            if (filter != null && !filter(fileInfo.FullName))
+                continue;
+            files.Add(fileInfo.FullName);
+        }
+        foreach (DirectoryInfo dirInfo in directoryInfo.GetDirectories())
+        {
+            List<string> subFiles = ScanFiles(dirInfo.FullName, filter);
+            if (subFiles != null) files.AddRange(subFiles);
+        }
+
+        return files;
+    }
+
+    class CustomScriptData
+    {
+        public string resourceName;
+        public string code;
+        public CustomScriptData(string resourceName, string code)
+        {
+            this.resourceName = resourceName;
+            this.code = code;
         }
     }
 }


### PR DESCRIPTION
在通过脚本调用webgl-jsbuild构建时, 可以自定义脚本内容. 这样就无需将output设置为Assets目录下(在打包时不再需要删除冗余资源), 也可以对脚本路径(resourceName)做更多个性化处理.